### PR TITLE
Rename `CNA` to `Aio`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+sudo: false
+git:
+  depth: 10
+
+os:
+  - windows
+  - linux
+
+node_js:
+  - "8"
+  - "10"
+  - "12"
+
+install:
+  - npm version
+  - npm install
+script:
+  - npm test
+
+after_success:
+- ./node_modules/.bin/codecov
+
+# safelist (prevent double builds in PRs)
+branches:
+  only:
+  - master
+  - /^greenkeeper/.*$/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This contains the base class for all Adobe I/O Core Errors. Use this as an Error
 
 This module was inspired by how Node.js creates its own Error classes.
 
-## CNACoreSDKError
+## AioCoreSDKError
 
 This is the base class for all the Error classes, and it should not be instantiated directly. Create your own subclass (dynamic usage) or use the ErrorWrapper below (static usage).
 
-The `message` property of `CNACoreSDKError` outputs the Error in this format:
+The `message` property of `AioCoreSDKError` outputs the Error in this format:
 ```bash
 [SDK:ERROR_CODE] ERROR_MESSAGE
 ```
@@ -31,18 +31,18 @@ Note that the `sdk details` is not displayed in the message. To see any `sdk det
 ## Dynamic Errors Usage
 
 ```javascript
-// Adobe I/O CNA Campaign Standard Wrapper
+// Adobe I/O Campaign Standard Wrapper
 
-const { CNACoreSDKError } = require('@adobe/adobe-io-cna-errors')
+const { AioCoreSDKError } = require('@adobe/aio-lib-errors')
 
 const gSDKDetails = {
   // ... add your sdk details here
   tenantId,
   endpoint
 }
-const gSDKName = "AdobeIOCNACampaignStandard"
+const gSDKName = "AdobeIOCampaignStandard"
 
-export default class CampaignStandardCoreAPIError extends CNACoreSDKError {
+export default class CampaignStandardCoreAPIError extends AioCoreSDKError {
   constructor(message, code) {
     // the sdk name and sdk details are curried in as the 3rd and 4th parameters
     super(message, code, gSDKName, gSDKDetails)
@@ -98,7 +98,7 @@ The example Usage above is for dynamic errors, for example API errors that we ar
 We define our specialized Error class, and error codes in its own module like so:
 ```javascript
 // SDKErrors.js
-const { ErrorWrapper, createUpdater } = require('@adobe/aio-lib-core-errors').CNACoreSDKErrorWrapper
+const { ErrorWrapper, createUpdater } = require('@adobe/aio-lib-core-errors').AioCoreSDKErrorWrapper
 
 const codes = {}
 const messages = new Map()
@@ -123,8 +123,8 @@ const E = ErrorWrapper(
   'MySDK',
   // the object returned from the CreateUpdater call above
   Updater
-  // the base class that your Error class is extending. CNACoreSDKError is the default
-  /* , CNACoreSDKError */
+  // the base class that your Error class is extending. AioCoreSDKError is the default
+  /* , AioCoreSDKError */
 )
 
 module.exports = {
@@ -150,7 +150,7 @@ This will dynamically create a `MySDKError` class with the appropriate closures 
 - error code (`UNKNOWN_ORDER_ID`, the first parameter passed in to `E`)
 - error message (`There was a problem with that order id: %s.`, the second parameter passed in to `E`. If this is a string with `format specifiers`, you can pass in arguments for the format specifiers, when the Error is constructed. See example below).
 ```javascript
-class MySDKError extends CNACoreSDKError { ... }
+class MySDKError extends AioCoreSDKError { ... }
 ```
 
 The line will add the dynamically created `MySDKError` class to the exported `codes` object, with the first parameter to the wrapper (the error code) as the key.
@@ -224,13 +224,13 @@ try {
 Output:
 ```bash
  { MySDKError: [MySDK:UNKNOWN_ORDER_ID] There was a problem with that order id: ORDER-21241-FSFS.
-          at new <anonymous> (/Users/obfuscated/adobeio-cna-errors/src/CNACoreSDKErrorWrapper.js:22:9)
-          at Object.<anonymous>.test (/Users/obfuscated/adobeio-cna-errors/test/MySDKError.test.js:50:15)
-          at Object.asyncJestTest (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)
-          at resolve (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/queueRunner.js:43:12)
+          at new <anonymous> (/Users/obfuscated/aio-lib-core-errors/src/AioCoreSDKErrorWrapper.js:22:9)
+          at Object.<anonymous>.test (/Users/obfuscated/aio-lib-core-errors/test/MySDKError.test.js:50:15)
+          at Object.asyncJestTest (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)
+          at resolve (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/queueRunner.js:43:12)
           at new Promise (<anonymous>)
-          at mapper (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/queueRunner.js:26:19)
-          at promise.then (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/queueRunner.js:73:41)
+          at mapper (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/queueRunner.js:26:19)
+          at promise.then (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/queueRunner.js:73:41)
           at process._tickCallback (internal/process/next_tick.js:68:7)
         code: 'UNKNOWN_ORDER_ID',
         sdk: 'MySDK',
@@ -270,6 +270,6 @@ Output:
 	},
 	"code": "UNKNOWN_ORDER_ID",
 	"message": "[MySDK:UNKNOWN_ORDER_ID] There was a problem with that order id: ORDER-21241-FSFS.",
-	"stacktrace": "MySDKError: [MySDK:UNKNOWN_ORDER_ID] There was a problem with that order id: ORDER-21241-FSFS.\n    at new <anonymous> (/Users/obfuscated/adobeio-cna-errors/src/CNACoreSDKErrorWrapper.js:22:9)\n    at Object.<anonymous>.test (/Users/obfuscated/adobeio-cna-errors/test/MySDKError.test.js:50:15)\n    at Object.asyncJestTest (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)\n    at resolve (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/queueRunner.js:43:12)\n    at new Promise (<anonymous>)\n    at mapper (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/queueRunner.js:26:19)\n    at promise.then (/Users/obfuscated/adobeio-cna-errors/node_modules/jest-jasmine2/build/queueRunner.js:73:41)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
+	"stacktrace": "MySDKError: [MySDK:UNKNOWN_ORDER_ID] There was a problem with that order id: ORDER-21241-FSFS.\n    at new <anonymous> (/Users/obfuscated/aio-lib-core-errors/src/AioCoreSDKErrorWrapper.js:22:9)\n    at Object.<anonymous>.test (/Users/obfuscated/aio-lib-core-errors/test/MySDKError.test.js:50:15)\n    at Object.asyncJestTest (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)\n    at resolve (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/queueRunner.js:43:12)\n    at new Promise (<anonymous>)\n    at mapper (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/queueRunner.js:26:19)\n    at promise.then (/Users/obfuscated/aio-lib-core-errors/node_modules/jest-jasmine2/build/queueRunner.js:73:41)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
+    "codecov": "^3.5.0",
     "eslint": "^6.2.2",
     "eslint-config-standard": "^14.0.1",
     "eslint-plugin-import": "^2.18.2",

--- a/src/AioCoreSDKError.js
+++ b/src/AioCoreSDKError.js
@@ -10,10 +10,10 @@ governing permissions and limitations under the License.
 */
 
 /**
- * Base class for all Adobe I/O CNA Core SDK Errors.
+ * Base class for all Adobe I/O Core SDK Errors.
  * Do not instantiate directly.
  */
-class CNACoreSDKError extends Error {
+class AioCoreSDKError extends Error {
   constructor (
     message = '<no_message>',
     code = '<unknown_code>',
@@ -25,7 +25,7 @@ class CNACoreSDKError extends Error {
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (captureStackTrace && captureStackTrace instanceof Function) {
-      captureStackTrace(this, CNACoreSDKError)
+      captureStackTrace(this, AioCoreSDKError)
     }
 
     this.code = code
@@ -47,4 +47,4 @@ class CNACoreSDKError extends Error {
   }
 }
 
-module.exports = CNACoreSDKError
+module.exports = AioCoreSDKError

--- a/src/AioCoreSDKErrorWrapper.js
+++ b/src/AioCoreSDKErrorWrapper.js
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 const util = require('util')
-const CNACoreSDKError = require('./CNACoreSDKError')
+const AioCoreSDKError = require('./AioCoreSDKError')
 
 /**
  * Returns a function that will dynamically create a class with the
@@ -23,9 +23,9 @@ const CNACoreSDKError = require('./CNACoreSDKError')
  * @param {string} errorClassName The class name for your SDK Error. Your Error objects will be these objects
  * @param {string} sdkName The name of your SDK. This will be a property in your Error objects
  * @param {function} Updater the object returned from a CreateUpdater call
- * @param {Class} BaseClass the base class that your Error class is extending. CNACoreSDKError is the default
+ * @param {Class} BaseClass the base class that your Error class is extending. AioCoreSDKError is the default
  */
-function ErrorWrapper (errorClassName, sdkName, Updater, BaseClass = CNACoreSDKError) {
+function ErrorWrapper (errorClassName, sdkName, Updater, BaseClass = AioCoreSDKError) {
   return function (code, message) {
     const createClass = curryCreateClass(errorClassName, sdkName, message, BaseClass)
     const clazz = createClass(code)

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const CNACoreSDKError = require('./CNACoreSDKError')
-const CNACoreSDKErrorWrapper = require('./CNACoreSDKErrorWrapper')
+const AioCoreSDKError = require('./AioCoreSDKError')
+const AioCoreSDKErrorWrapper = require('./AioCoreSDKErrorWrapper')
 
 module.exports = {
-  CNACoreSDKError,
-  CNACoreSDKErrorWrapper
+  AioCoreSDKError,
+  AioCoreSDKErrorWrapper
 }

--- a/test/AioCoreSDKError.test.js
+++ b/test/AioCoreSDKError.test.js
@@ -9,16 +9,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { CNACoreSDKError } = require('../src')
+const { AioCoreSDKError } = require('../src')
 
-test('CNACoreSDKError default', () => {
+test('AioCoreSDKError default', () => {
   const sdk = '<unknown_sdk>'
   const sdkDetails = {}
   const message = '<no_message>'
   const code = '<unknown_code>'
 
   // Default, no arguments
-  const err = new CNACoreSDKError()
+  const err = new AioCoreSDKError()
 
   expect(err instanceof Object).toBeTruthy()
   expect(err.sdk).toEqual(sdk)
@@ -27,14 +27,14 @@ test('CNACoreSDKError default', () => {
   expect(err.code).toEqual(code)
 })
 
-test('CNACoreSDKError with parameters', () => {
+test('AioCoreSDKError with parameters', () => {
   const sdk = 'MySDK'
   const sdkDetails = { endpoint: 'http://foo.bar' }
   const message = 'This is an error message'
   const code = 'ERR_CODE_1'
 
   // set some arguments
-  const err = new CNACoreSDKError(message, code, sdk, sdkDetails, null)
+  const err = new AioCoreSDKError(message, code, sdk, sdkDetails, null)
 
   expect(err instanceof Object).toBeTruthy()
   expect(err.sdk).toEqual(sdk)

--- a/test/MySDKError.test.js
+++ b/test/MySDKError.test.js
@@ -13,7 +13,7 @@ const util = require('util')
 
 const { codes, messages } = require('./classes/MySDKError')
 const { UNKNOWN_THING_ID, UNKNOWN_ORDER_ID } = require('./classes/MySDKError').codes
-const { CNACoreSDKError } = require('../src')
+const { AioCoreSDKError } = require('../src')
 
 test('codes', () => {
   expect(codes.UNKNOWN_THING_ID).toBeDefined()
@@ -31,7 +31,7 @@ test('UNKNOWN_THING_ID default', () => {
   // You can pass in the sdkDetails, or not
   const err = new UNKNOWN_THING_ID()
 
-  expect(err instanceof CNACoreSDKError).toBeTruthy()
+  expect(err instanceof AioCoreSDKError).toBeTruthy()
   expect(err.sdk).toEqual(sdk)
   expect(err.sdkDetails).toEqual(sdkDetails)
   expect(err.message).toEqual(`[${sdk}:${code}] ${message}`)

--- a/test/classes/MySDKError.js
+++ b/test/classes/MySDKError.js
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { ErrorWrapper, createUpdater } = require('../../src').CNACoreSDKErrorWrapper
+const { ErrorWrapper, createUpdater } = require('../../src').AioCoreSDKErrorWrapper
 
 const codes = {}
 const messages = new Map()
@@ -34,8 +34,8 @@ const E = ErrorWrapper(
   'MySDK',
   // the object returned from the CreateUpdater call above
   Updater
-  // the base class that your Error class is extending. CNACoreSDKError is the default
-  /* CNACoreSDKError, */
+  // the base class that your Error class is extending. AioCoreSDKError is the default
+  /* AioCoreSDKError, */
 )
 
 module.exports = {


### PR DESCRIPTION
This PR renames all instances of `CNA` to `Aio`. 
Once this is merged in, it should require a major version bump.