### PR TITLE
fix: restrict npm pack to src folder only

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "jest": "^24.9.0",
     "jsdoc-to-markdown": "^5.0.1",
     "tsd-jsdoc": "^2.4.0"
-  }
+  },
+  "files": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Fixes #12 

## How Has This Been Tested?

1. npm pack
2. extract the tarball
3. npm init -y
4. npm install path/to/extracted/tarball
5. inspect node_modules

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
